### PR TITLE
fix(builld): fix image order to match dockerfile order

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Set up commands
       run: |
-        $images = @("azdevops-build-agent:dev$($env:branch)-bcagent-k8s","azdevops-build-agent:dev$($env:branch)-bcagent", "azdevops-build-agent:dev$($env:branch)-coreagent", "azdevops-build-agent:dev$($env:branch)-vsceagent")
+        $images = @("azdevops-build-agent:dev$($env:branch)-bcagent","azdevops-build-agent:dev$($env:branch)-bcagent-k8s", "azdevops-build-agent:dev$($env:branch)-coreagent", "azdevops-build-agent:dev$($env:branch)-vsceagent")
         $targets = @("ltsc2019", "2004", "ltsc2022")
         $dockerfiles = @("Dockerfile.bcagent","Dockerfile.bcagent-k8s", "Dockerfile.coreagent", "Dockerfile.vsceagent")
 


### PR DESCRIPTION
because the image/tag order and the dockerfile order is different, the bcagent-k8s image is built from the bcagent Dockerfile and vice versa 
[AB#4340](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4340)