### PR TITLE
chore: remove obsolete base images

### DIFF
--- a/.github/workflows/build-image-on-push.yml
+++ b/.github/workflows/build-image-on-push.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up commands
       run: |
         $images = @("azdevops-build-agent:dev$($env:branch)-bcagent","azdevops-build-agent:dev$($env:branch)-bcagent-k8s", "azdevops-build-agent:dev$($env:branch)-coreagent", "azdevops-build-agent:dev$($env:branch)-vsceagent")
-        $targets = @("ltsc2019", "2004", "ltsc2022")
+        $targets = @("ltsc2022")
         $dockerfiles = @("Dockerfile.bcagent","Dockerfile.bcagent-k8s", "Dockerfile.coreagent", "Dockerfile.vsceagent")
 
         $buildCmds = New-Object System.Collections.Generic.List[System.String]

--- a/.github/workflows/build-image-on-tag.yml
+++ b/.github/workflows/build-image-on-tag.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         $version = ((Invoke-Expression "git describe --abbrev=0 --tags").Substring(1))
         $images = @("azdevops-build-agent:$($version)-bcagent-k8s","azdevops-build-agent:latest-bcagent-k8s","azdevops-build-agent:$($version)-bcagent", "azdevops-build-agent:latest-bcagent", "azdevops-build-agent:$($version)-coreagent", "azdevops-build-agent:latest-coreagent", "azdevops-build-agent:$($version)-vsceagent", "azdevops-build-agent:latest-vsceagent")
-        $targets = @("ltsc2019", "2004", "ltsc2022")
+        $targets = @("ltsc2022")
         $dockerfiles = @("Dockerfile.bcagent-k8s", "Dockerfile.bcagent-k8s", "Dockerfile.bcagent", "Dockerfile.bcagent", "Dockerfile.coreagent", "Dockerfile.coreagent", "Dockerfile.vsceagent", "Dockerfile.vsceagent")
 
         $buildCmds = New-Object System.Collections.Generic.List[System.String]


### PR DESCRIPTION
2004 and ltsc2019 are no longer relevant

[AB#4340](https://dev.azure.com/cc-ppi/83f75d99-795d-45dc-8543-9fe1918ff7f9/_workitems/edit/4340)